### PR TITLE
Use Animated and remove react-tween-state

### DIFF
--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -1,10 +1,11 @@
 var React = require('react-native');
+
 var {
+  Animated,
+  Easing,
   StyleSheet,
   View
 } = React;
-var tweenState = require('react-tween-state');
-
 
 var styles = StyleSheet.create({
   background: {
@@ -18,53 +19,49 @@ var styles = StyleSheet.create({
   }
 });
 
-
 var ProgressBar = React.createClass({
-
-  mixins: [tweenState.Mixin],
 
   getDefaultProps() {
     return {
       style: styles,
-      easing: tweenState.easingTypes.easeInOutQuad,
+      easing: Easing.inOut(Easing.ease),
       easingDuration: 500
     };
   },
 
   getInitialState() {
     return {
-      progress: 0
+      progress: new Animated.Value(0)
     };
   },
 
   componentDidUpdate(prevProps, prevState) {
     if (this.props.progress >= 0 && this.props.progress != prevProps.progress) {
-      this.update(this.props.progress);
+      this.update();
     }
   },
 
   render() {
 
-    var progress = this.getTweeningValue('progress') || this.props.progress;
-
-    var fillWidth = progress * this.props.style.width;
+    var fillWidth = this.state.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0 * this.props.style.width, 1 * this.props.style.width],
+    });
 
     return (
       <View style={[styles.background, this.props.backgroundStyle, this.props.style]}>
-        <View style={[styles.fill, this.props.fillStyle, { width: fillWidth }]}/>
+        <Animated.View style={[styles.fill, this.props.fillStyle, { width: fillWidth }]}/>
       </View>
     );
   },
 
-  update(progress) {
-    this.tweenState('progress', {
+  update() {
+    Animated.timing(this.state.progress, {
       easing: this.props.easing,
       duration: this.props.easingDuration,
-      endValue: this.props.progress
-    });
+      toValue: this.props.progress
+    }).start();
   }
 });
-
-ProgressBar.easingTypes = tweenState.easingTypes;
 
 module.exports = ProgressBar;


### PR DESCRIPTION
This is initial proposal to use [Animated](https://facebook.github.io/react-native/docs/animations.html#animated) instead of [react-tween-state](https://github.com/chenglou/react-tween-state). If approved next step is to update documentation.
