### PR TITLE
fix display of fill bar

### DIFF
--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -23,7 +23,7 @@ var ProgressBar = React.createClass({
 
   getDefaultProps() {
     return {
-      style: styles,
+      style: {width: 20},
       easing: Easing.inOut(Easing.ease),
       easingDuration: 500
     };
@@ -42,11 +42,12 @@ var ProgressBar = React.createClass({
   },
 
   render() {
-
-    var fillWidth = this.state.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0 * this.props.style.width, 1 * this.props.style.width],
+    var i = this.state.progress.interpolate({
+      inputRange: [0.0, 1.0],
+      outputRange: [0.0, 1.0 * this.props.style.width],
     });
+
+    var fillWidth = i._interpolation(1.0 * this.props.progress)
 
     return (
       <View style={[styles.background, this.props.backgroundStyle, this.props.style]}>


### PR DESCRIPTION
So I noticed an exception in the chrome debug window where the value of the `styles` variable was being applied directly to the element. So getting an invalid attribute `background` error.

I've just hacked around until it works locally, but thought I'd raise it here as a discussion before looking at doing a proper pull request.

I'm using `react-native` `0.10.0`

I couldn't see how this code was ever working as the value of `fillWidth` is an object used to calculate interpolations. 

Was I doing something wrong or am I right in thinking that this has never worked?
