### PR TITLE
Start progress from props

### DIFF
--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -31,7 +31,7 @@ var ProgressBar = React.createClass({
 
   getInitialState() {
     return {
-      progress: new Animated.Value(0)
+      progress: new Animated.Value(this.props.progress)
     };
   },
 


### PR DESCRIPTION
I'd like to use this bar as a video seeker but I realized that you start from `0` regardless of the given value. So if I want to continue from the middle of the video, there's a weird animation at the beginning while it catches up to the current time. I've changed the initial value so it's initialized from the `props`. This also could be optional. Let me know what you think.
