### PR TITLE
Android support, choose whether to animate to the first value or not and support for int ranges

### DIFF
--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -64,7 +64,7 @@ var ProgressBar = React.createClass({
     );
   },
 
-  animate(progress) {
+  animate() {
     Animated.timing(this.state.progress, {
       easing: this.props.easing,
       duration: this.props.easingDuration,

--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -19,33 +19,42 @@ var styles = StyleSheet.create({
   }
 });
 
+var ALMOST_ZERO = 0.0000001;
+
 var ProgressBar = React.createClass({
 
   getDefaultProps() {
     return {
       style: styles,
       easing: Easing.inOut(Easing.ease),
-      easingDuration: 500
+      easingDuration: 500,
+      animateOnLoad: true,
+      useFloat: true
     };
   },
 
   getInitialState() {
     return {
-      progress: new Animated.Value(0)
+      progress: new Animated.Value(this.props.animateOnLoad ? ALMOST_ZERO : this.props.progress)
     };
   },
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props.progress >= 0 && this.props.progress != prevProps.progress) {
-      this.update();
+    if (this.props.progress >= ALMOST_ZERO && this.props.progress != prevProps.progress) {
+      this.animate();
+    }
+  },
+
+  componentDidMount() {
+    if (this.props.animateOnLoad && this.props.progress > ALMOST_ZERO) {
+      this.animate();
     }
   },
 
   render() {
-
     var fillWidth = this.state.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0 * this.props.style.width, 1 * this.props.style.width],
+      inputRange : this.props.useFloat ? [0.0, 1.0] : [0, 100],
+      outputRange: [ALMOST_ZERO, this.props.style.width]
     });
 
     return (
@@ -55,7 +64,7 @@ var ProgressBar = React.createClass({
     );
   },
 
-  update() {
+  animate(progress) {
     Animated.timing(this.state.progress, {
       easing: this.props.easing,
       duration: this.props.easingDuration,


### PR DESCRIPTION
- Added a property that allows you to choose whether to use floats or int.
- Added a property that allows you to specify whether to animate on load. This is based on the idea submitted by berkcaputcu but rather than having another 'initialProgress' it explicitly sets the state to 0 and animates to the first progress value unless you set the animateOnLoad flag to be false.
