### PR TITLE
Flexbox used instead of fixed width.

### DIFF
--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -8,60 +8,66 @@ import {
 } from 'react-native';
 
 var styles = StyleSheet.create({
-  background: {
-    backgroundColor: '#bbbbbb',
-    height: 5,
-    overflow: 'hidden'
-  },
-  fill: {
-    backgroundColor: '#3b5998',
-    height: 5
-  }
+    background: {
+        backgroundColor: '#bbbbbb',
+        height: 5,
+        overflow: 'hidden'
+    },
+    fill: {
+        backgroundColor: '#3b5998',
+        height: 5
+    }
 });
 
 var ProgressBar = React.createClass({
 
-  getDefaultProps() {
-    return {
-      style: styles,
-      easing: Easing.inOut(Easing.ease),
-      easingDuration: 500
-    };
-  },
+    getDefaultProps() {
+        return {
+            style: styles,
+            easing: Easing.inOut(Easing.ease),
+            easingDuration: 500
+        };
+    },
 
-  getInitialState() {
-    return {
-      progress: new Animated.Value(this.props.initialProgress || 0)
-    };
-  },
+    getInitialState() {
+        return {
+            progress: new Animated.Value(this.props.initialProgress || 0),
+            calculatedWidth: 0
+        };
+    },
 
-  componentDidUpdate(prevProps, prevState) {
-    if (this.props.progress >= 0 && this.props.progress != prevProps.progress) {
-      this.update();
+    componentDidUpdate(prevProps, prevState) {
+        if (this.props.progress >= 0 && this.props.progress != prevProps.progress) {
+            this.update();
+        }
+    },
+
+    render() {
+        var fillWidth = this.state.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0 * (this.props.style.width || this.state.calculatedWidth ),
+                1 * (this.props.style.width || this.state.calculatedWidth)],
+        });
+
+        return (
+            <View style={[styles.background, this.props.backgroundStyle, this.props.style]}
+                  onLayout={(event) => {
+                      if (!this.props.style.width) {
+                          this.setState({calculatedWidth: event.nativeEvent.layout.width})
+                      }
+                  }}>
+                <Animated.View style={[styles.fill, this.props.fillStyle, {width: fillWidth}]}/>
+            </View>
+        );
+    },
+
+    update() {
+        Animated.timing(this.state.progress, {
+            easing: this.props.easing,
+            duration: this.props.easingDuration,
+            toValue: this.props.progress
+        }).start();
     }
-  },
-
-  render() {
-
-    var fillWidth = this.state.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0 * this.props.style.width, 1 * this.props.style.width],
-    });
-
-    return (
-      <View style={[styles.background, this.props.backgroundStyle, this.props.style]}>
-        <Animated.View style={[styles.fill, this.props.fillStyle, { width: fillWidth }]}/>
-      </View>
-    );
-  },
-
-  update() {
-    Animated.timing(this.state.progress, {
-      easing: this.props.easing,
-      duration: this.props.easingDuration,
-      toValue: this.props.progress
-    }).start();
-  }
 });
 
 module.exports = ProgressBar;

--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -8,66 +8,67 @@ import {
 } from 'react-native';
 
 var styles = StyleSheet.create({
-    background: {
-        backgroundColor: '#bbbbbb',
-        height: 5,
-        overflow: 'hidden'
-    },
-    fill: {
-        backgroundColor: '#3b5998',
-        height: 5
-    }
+  background: {
+    backgroundColor: '#bbbbbb',
+    height: 5,
+    overflow: 'hidden'
+  },
+  fill: {
+    backgroundColor: '#3b5998',
+    height: 5
+  }
 });
 
 var ProgressBar = React.createClass({
 
-    getDefaultProps() {
-        return {
-            style: styles,
-            easing: Easing.inOut(Easing.ease),
-            easingDuration: 500
-        };
-    },
+  getDefaultProps() {
+    return {
+      style: styles,
+      easing: Easing.inOut(Easing.ease),
+      easingDuration: 500
+    };
+  },
 
-    getInitialState() {
-        return {
-            progress: new Animated.Value(this.props.initialProgress || 0),
-            calculatedWidth: 0
-        };
-    },
+  getInitialState() {
+    return {
+      progress: new Animated.Value(this.props.initialProgress || 0),
+      calculatedWidth: 0
+    };
+  },
 
-    componentDidUpdate(prevProps, prevState) {
-        if (this.props.progress >= 0 && this.props.progress != prevProps.progress) {
-            this.update();
-        }
-    },
-
-    render() {
-        var fillWidth = this.state.progress.interpolate({
-            inputRange: [0, 1],
-            outputRange: [0 * (this.props.style.width || this.state.calculatedWidth ),
-                1 * (this.props.style.width || this.state.calculatedWidth)],
-        });
-
-        return (
-            <View style={[styles.background, this.props.backgroundStyle, this.props.style]}
-                  onLayout={(event) => {
-                      if (!this.props.style.width) {
-                          this.setState({calculatedWidth: event.nativeEvent.layout.width})
-                      }
-                  }}>
-                <Animated.View style={[styles.fill, this.props.fillStyle, {width: fillWidth}]}/>
-            </View>
-        );
-    },
-
-    update() {
-        Animated.timing(this.state.progress, {
-            easing: this.props.easing,
-            duration: this.props.easingDuration,
-            toValue: this.props.progress
-        }).start();
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.progress >= 0 && this.props.progress != prevProps.progress) {
+      this.update();
     }
+  },
+
+  render() {
+
+    var fillWidth = this.state.progress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0 * (this.props.style.width || this.state.calculatedWidth ),
+          1 * (this.props.style.width || this.state.calculatedWidth)]
+    });
+
+    return (
+      <View style={[styles.background, this.props.backgroundStyle, this.props.style]}
+            onLayout={(event) => {
+               if (!this.props.style.width) {
+                    this.setState({calculatedWidth: event.nativeEvent.layout.width})
+                    }
+                }}>
+        <Animated.View style={[styles.fill, this.props.fillStyle, { width: fillWidth }]}/>
+      </View>
+    );
+  },
+
+  update() {
+    Animated.timing(this.state.progress, {
+      easing: this.props.easing,
+      duration: this.props.easingDuration,
+      toValue: this.props.progress
+    }).start();
+  }
 });
 
 module.exports = ProgressBar;


### PR DESCRIPTION
The component made work with also relative width (flex etc..) 
For  example: 

``` 
<ProgressBar
          fillStyle={{}}
          backgroundStyle={{backgroundColor: '#cccccc', borderRadius: 2}}
          style={{marginTop: 10, width: 300}}
          progress={this.state.progress}
  />
```

if we change the `width:300`  to  `flex:1` at above sample  as shown below, progress-bar will not work because there is no fixed width property on style prop. 

```
<ProgressBar
          fillStyle={{}}
          backgroundStyle={{backgroundColor: '#cccccc', borderRadius: 2}}
          style={{marginTop: 10, flex:1}}
          progress={this.state.progress}
      />
```
we can find the progress-bars width ourselves through code. this pr aims to made the plugin work with relative widths also. by detecting the width of progress programatically.