### PR TITLE
invalid default style prop

### DIFF
--- a/ProgressBar.js
+++ b/ProgressBar.js
@@ -23,7 +23,7 @@ var ProgressBar = React.createClass({
 
   getDefaultProps() {
     return {
-      style: styles,
+      style: {},
       easing: Easing.inOut(Easing.ease),
       easingDuration: 500
     };


### PR DESCRIPTION
invalid default style prop caused warning when not specified (Failed prop type: Invalid props.style key 'background' supplied to 'View')